### PR TITLE
Adds support for deltas in gauge

### DIFF
--- a/src/main/java/tech/energyit/statsd/StatsDClient.java
+++ b/src/main/java/tech/energyit/statsd/StatsDClient.java
@@ -21,6 +21,18 @@ public interface StatsDClient {
     void gauge(byte[] aspect, long value, Tag... tags);
 
     /**
+     * Records the delta value for the specified named gauge.
+     *
+     * @param aspect
+     *     the name of the gauge
+     * @param deltaSign
+     *     either '+' or '-' to indicate either increase or decrease gauge value
+     * @param value
+     *     the (positive!) change of value
+     */
+    void gauge(byte[] aspect, char deltaSign, long value, Tag... tags);
+
+    /**
      * Records the latest fixed value for the specified named gauge.
      *
      * @param aspect     the name of the gauge
@@ -37,6 +49,18 @@ public interface StatsDClient {
      * @param value  the new reading of the gauge
      */
     void gauge(byte[] aspect, double value, Tag... tags);
+
+    /**
+     * Records the delta value for the specified named gauge.
+     *
+     * @param aspect
+     *     the name of the gauge
+     * @param deltaSign
+     *     either '+' or '-' to indicate either increase or decrease gauge value
+     * @param value
+     *     the (positive!) change of value
+     */
+    void gauge(byte[] aspect, char deltaSign, double value, Tag... tags);
 
     /**
      * Records the latest fixed value for the specified named gauge.

--- a/src/test/java/tech/energyit/statsd/FastStatsDClientTest.java
+++ b/src/test/java/tech/energyit/statsd/FastStatsDClientTest.java
@@ -100,6 +100,12 @@ public class FastStatsDClientTest {
     }
 
     @Test
+    public void longGaugeWithDeltaSignShouldBeSendCorrectly() {
+        statsDClient.gauge("my.metric".getBytes(), '+', 10);
+        assertThat(sender.getMessages()).containsExactly("my.prefix.my.metric:+10|g");
+    }
+
+    @Test
     public void gaugeWithRateShouldBeSendCorrectly() {
         statsDClient.gauge("my.metric".getBytes(), 10, 0.1);
         assertThat(sender.getMessages()).containsExactly("my.prefix.my.metric:10|g|@0.1");
@@ -115,6 +121,12 @@ public class FastStatsDClientTest {
     public void doubleGaugeShouldBeSendCorrectly() {
         statsDClient.gauge("my.metric".getBytes(), -10.45678);
         assertThat(sender.getMessages()).containsExactly("my.prefix.my.metric:-10.45678|g");
+    }
+
+    @Test
+    public void doubleWithSignGaugeShouldBeSendCorrectly() {
+        statsDClient.gauge("my.metric".getBytes(), '+', 10.45678);
+        assertThat(sender.getMessages()).containsExactly("my.prefix.my.metric:+10.45678|g");
     }
 
     @Test


### PR DESCRIPTION
Prependning '+' or '-' sign to the gauge makes the value to be taken as a delta (see Gauges section here: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/statsd/README.md ), which might be useful for some applications